### PR TITLE
fix(tui): restore beacon indicator for disabled AprsIS sinks

### DIFF
--- a/rigtop/sinks/tui.py
+++ b/rigtop/sinks/tui.py
@@ -1358,8 +1358,15 @@ class RigtopApp(App[None]):
         )
         aprsis_sinks = [s for s in self._sinks if type(s).__name__ == "AprsIsSink"]
         if aprsis_sinks:
-            s = aprsis_sinks[0]
-            beacon_enabled = s._beacon_enabled and s.connected
+            # Prefer a connected sink, then an enabled one, else the first configured
+            s = (
+                next((x for x in aprsis_sinks if getattr(x, "connected", False)), None)
+                or next((x for x in aprsis_sinks if getattr(x, "_beacon_enabled", False)), None)
+                or aprsis_sinks[0]
+            )
+            beacon_enabled = bool(getattr(s, "_beacon_enabled", False)) and bool(
+                getattr(s, "connected", False)
+            )
         else:
             beacon_enabled = None
         self.query_one(StationPanel).render_data(

--- a/tests/test_tui_controls.py
+++ b/tests/test_tui_controls.py
@@ -2,7 +2,53 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from rigtop.sinks.tui import _control_bar
+
+
+def _make_aprs_sink(*, connected: bool, beacon_enabled: bool, enabled: bool = True):
+    return SimpleNamespace(
+        connected=connected,
+        _beacon_enabled=beacon_enabled,
+        enabled=enabled,
+    )
+
+
+def _pick_beacon(sinks):
+    """Mirror the sink-selection logic from RigtopApp._apply_data."""
+    aprsis = [s for s in sinks if True]  # all sinks passed here are already AprsIS
+    if not aprsis:
+        return None
+    s = (
+        next((x for x in aprsis if getattr(x, "connected", False)), None)
+        or next((x for x in aprsis if getattr(x, "_beacon_enabled", False)), None)
+        or aprsis[0]
+    )
+    return bool(getattr(s, "_beacon_enabled", False)) and bool(getattr(s, "connected", False))
+
+
+class TestBeaconIndicator:
+    def test_disabled_sink_returns_false_not_none(self):
+        sink = _make_aprs_sink(connected=False, beacon_enabled=True, enabled=False)
+        result = _pick_beacon([sink])
+        assert result is False  # shows ○ OFF, not hidden
+
+    def test_connected_sink_beacon_on(self):
+        sink = _make_aprs_sink(connected=True, beacon_enabled=True)
+        assert _pick_beacon([sink]) is True
+
+    def test_connected_sink_beacon_off(self):
+        sink = _make_aprs_sink(connected=True, beacon_enabled=False)
+        assert _pick_beacon([sink]) is False
+
+    def test_prefers_connected_over_disabled(self):
+        disabled = _make_aprs_sink(connected=False, beacon_enabled=True, enabled=False)
+        active = _make_aprs_sink(connected=True, beacon_enabled=True)
+        assert _pick_beacon([disabled, active]) is True
+
+    def test_no_sinks_returns_none(self):
+        assert _pick_beacon([]) is None
 
 
 class TestControlBar:


### PR DESCRIPTION
## Summary

- The `enabled` filter added to prevent disabled sinks from connecting also accidentally excluded them from the beacon indicator lookup
- When `enabled = false` in config, `beacon_enabled` became `None` and the `Beacon: ●/○` row vanished from the Station panel
- Fix: look up all configured AprsIS sinks for the indicator regardless of `enabled` flag — a disabled sink won't be connected so it correctly shows `○ OFF`

## Test plan
- [ ] Set `enabled = false` on `[sink] type = "aprsis"` — beacon row should still show `○ OFF` in the Station panel
- [ ] Set `enabled = true` and connect — beacon row shows `● ON` when beacon is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)