### PR TITLE
ci: fold build and release into bump.yml

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   bump:
-    name: cz bump → push tag → trigger release
+    name: cz bump → build → release
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: write   # push tag + create GitHub release
+      id-token: write   # OIDC for PyPI trusted publishing (future use)
 
     steps:
       - uses: actions/checkout@v6
@@ -41,12 +42,26 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version
+        id: bump
         run: |
           if [ -n "${{ inputs.increment }}" ]; then
             uv run cz bump --increment ${{ inputs.increment }} --yes
           else
             uv run cz bump --yes
           fi
+          NEW_TAG=$(git describe --tags --abbrev=0)
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Push commit and tag
         run: git push --follow-tags
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.bump.outputs.tag }}
+          files: dist/*
+          generate_release_notes: true
+          make_latest: true


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN`-pushed tags don't trigger other workflow runs — `release.yml` never fired, so no wheels or GitHub Releases were ever published
- Folds the build (`uv build`) and `softprops/action-gh-release` steps directly into `bump.yml`, eliminating the cascade dependency
- Captures the new tag via `git describe --tags --abbrev=0` after `cz bump` and passes it as a step output to the release step

## Test plan
- [ ] Trigger `Bump version` workflow manually (workflow_dispatch) after merge
- [ ] Verify a GitHub Release is created with sdist + wheel attached
- [ ] `release.yml` remains for manual tag-based triggers (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)